### PR TITLE
Fix provisioning loop to consider other clouds

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSProvisioningStrategy.java
@@ -59,7 +59,10 @@ public class ECSProvisioningStrategy extends NodeProvisioner.Strategy {
             if (c instanceof ECSCloud) {
                 provisioningCapacity = ((ECSCloud) c).getProvisioningCapacity(excessWorkload, snap.getOnlineExecutors(), snap.getConnectingExecutors());
                 if (provisioningCapacity == 0) {
-                    return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+                    // If this cloud cannot provision any more agents let the
+                    // strategy continue with the remaining clouds instead of
+                    // aborting provisioning entirely.
+                    continue;
                 }
             }
             int requestAdditionalCapacities = provisioningCapacity == 0 ? excessWorkload : provisioningCapacity;


### PR DESCRIPTION
## Summary
- avoid stopping provisioning when first ECS cloud is at capacity

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432c1e7328832295f4b33209c9d7dd