### PR TITLE
Add warm agent pool support

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSAgentPoolMaintainer.java
@@ -1,0 +1,71 @@
+package com.cloudbees.jenkins.plugins.amazonecs;
+
+import hudson.Extension;
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.TaskListener;
+import hudson.model.Computer;
+import hudson.slaves.Cloud;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+// ECS classes
+import com.cloudbees.jenkins.plugins.amazonecs.ECSCloud;
+import com.cloudbees.jenkins.plugins.amazonecs.ECSTaskTemplate;
+import com.cloudbees.jenkins.plugins.amazonecs.ECSSlave;
+import com.cloudbees.jenkins.plugins.amazonecs.ECSComputer;
+
+@Extension
+public class ECSAgentPoolMaintainer extends AsyncPeriodicWork {
+
+    private static final Logger LOGGER = Logger.getLogger(ECSAgentPoolMaintainer.class.getName());
+
+    public ECSAgentPoolMaintainer() {
+        super("ECS Agent Pool Maintainer");
+    }
+
+    @Override
+    public long getRecurrencePeriod() {
+        return TimeUnit.MINUTES.toMillis(1);
+    }
+
+    @Override
+    protected void execute(TaskListener listener) throws IOException, InterruptedException {
+        for (Cloud c : Jenkins.get().clouds) {
+            if (c instanceof ECSCloud) {
+                ECSCloud cloud = (ECSCloud) c;
+                for (ECSTaskTemplate t : cloud.getAllTemplates()) {
+                    if (t.getMinIdleAgents() <= 0 || !t.isScheduleActive()) {
+                        continue;
+                    }
+                    int current = countIdle(t);
+                    while (current < t.getMinIdleAgents()) {
+                        try {
+                            ECSSlave s = cloud.provisionSlaveForTemplate(t);
+                            listener.getLogger().println("Pre-launched ECS agent " + s.getNodeName());
+                            current++;
+                        } catch (Exception ex) {
+                            LOGGER.log(Level.WARNING, "Failed to pre-launch agent for template " + t.getTemplateName(), ex);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private int countIdle(ECSTaskTemplate template) {
+        int count = 0;
+        for (Computer c : Jenkins.get().getComputers()) {
+            if (c instanceof ECSComputer) {
+                ECSSlave node = ((ECSComputer) c).getNode();
+                if (node != null && node.getTemplate().equals(template) && c.isIdle()) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -413,6 +413,21 @@ public class ECSCloud extends Cloud {
         setTemplates(result);
     }
 
+    public ECSSlave provisionSlaveForTemplate(ECSTaskTemplate template) throws Descriptor.FormException, IOException {
+        String parentLabel = template.getInheritFrom();
+        final ECSTaskTemplate merged = template.merge(getTemplate(parentLabel));
+        String labelName = Optional.ofNullable(template.getLabel()).orElse("ecs");
+        Label label = Label.parse(labelName).iterator().next();
+        String agentName = name + "-" + label.getName() + "-" + RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        ECSSlave slave = new ECSSlave(ECSCloud.this, agentName, merged, new ECSLauncher(ECSCloud.this, tunnel, null));
+        Jenkins.get().addNode(slave);
+        Computer c = slave.toComputer();
+        if (c != null) {
+            c.connect(false);
+        }
+        return slave;
+    }
+
     private class ProvisioningCallback implements Callable<Node> {
 
         private final ECSTaskTemplate template;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/config.jelly
@@ -327,5 +327,11 @@
         </table>
       </f:repeatable>
     </f:entry>
+    <f:entry title="${%Minimum Idle Agents}" field="minIdleAgents">
+      <f:number default="0" />
+    </f:entry>
+    <f:entry title="${%Maintain Schedule}" field="maintainSchedule">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-maintainSchedule.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-maintainSchedule.html
@@ -1,0 +1,5 @@
+<p>
+  Cron syntax controlling when the plugin should maintain the minimum
+  number of idle agents. Leave empty to keep the pool at all times.
+  Uses the standard Jenkins cron format.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-minIdleAgents.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/ECSTaskTemplate/help-minIdleAgents.html
@@ -1,0 +1,5 @@
+<p>
+  Number of agent tasks to keep pre-launched and ready for use.
+  When the number of idle agents falls below this value, the plugin
+  will start additional agents to replenish the pool.
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/amazonecs/Messages.properties
@@ -25,3 +25,5 @@
 
 displayName=Amazon EC2 Container Service Cloud
 template=ECS Task template
+Minimum\ Idle\ Agents=Minimum Idle Agents
+Maintain\ Schedule=Maintain Schedule


### PR DESCRIPTION
## Summary
- allow templates to specify a minimum number of idle agents and a cron schedule
- expose new fields in UI and help docs
- implement `ECSAgentPoolMaintainer` to keep the pool filled
- expose helper `provisionSlaveForTemplate` for internal use

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432c9127e48322b776b4f4df05154d